### PR TITLE
Fixing API documentation to reflect limit of 6000

### DIFF
--- a/simplegetapi/templates/simplegetapi/documentation_generalopts.html
+++ b/simplegetapi/templates/simplegetapi/documentation_generalopts.html
@@ -6,7 +6,7 @@
 
 <h3>Limit/Offset</h3>
 
-<p>Results are paged 100 per call by default. This is true even in CSV format. Set the <tt>limit</tt> parameter to a high value to get all of the results at once. Use <tt>offset</tt> to page through results. The maximum limit is 600.</p>
+<p>Results are paged 100 per call by default. This is true even in CSV format. Set the <tt>limit</tt> parameter to a high value to get all of the results at once. Use <tt>offset</tt> to page through results. The maximum limit is 6000.</p>
 
 <h3>Sort</h3>
 


### PR DESCRIPTION
resolves govtrack/govtrack.us-web#112
Updates API documentation to specify a limit of 6000 instead of 600.

API was tested and 6000 appears to be the correct limit:

<img width="369" alt="screen shot 2016-06-19 at 10 32 47 am" src="https://cloud.githubusercontent.com/assets/628821/16178975/724f6536-360c-11e6-9ed5-3a3db5e8adf5.png">

<img width="451" alt="screen shot 2016-06-19 at 10 32 58 am" src="https://cloud.githubusercontent.com/assets/628821/16178976/7774119c-360c-11e6-8f01-c7dd2e90c6d7.png">
